### PR TITLE
Исправления ошибок fast api

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -57,9 +57,9 @@ def get_filename_without_ext(filename):
     return path.splitext(filename)[0]
 
 @app.post("/uploadfile/")
-async def upload_file(selected_file: UploadFile):
-    pred = manager.predict(selected_file.file.read())
-    filename = get_filename_without_ext(selected_file.filename)
+async def upload_file(selectedFile: UploadFile):
+    pred = manager.predict(selectedFile.file.read())
+    filename = get_filename_without_ext(selectedFile.filename)
 
     response = StreamingResponse(io.BytesIO(pred), media_type="image/jpg")
     response.headers["Content-Disposition"] = f"attachment;filename={filename}_predicted.jpg"

--- a/api/main.py
+++ b/api/main.py
@@ -1,21 +1,15 @@
-﻿from fastapi import FastAPI, File, UploadFile
-from starlette.middleware.cors import CORSMiddleware
-from starlette_exporter import PrometheusMiddleware, handle_metrics
-
-import numpy as np
-import pandas as pd
-from src.features_extraction_algorithms.hog_algorithm import HogPredict
-
-from starlette.responses import StreamingResponse
-
-from src.factoring.yolo_manager_factory import YoloManagerFactory
-import io
+﻿import io
 import zipfile
 from os import path
-import cv2
+
+from fastapi import FastAPI, UploadFile
+from starlette.middleware.cors import CORSMiddleware
+from starlette.responses import StreamingResponse
+from starlette_exporter import PrometheusMiddleware, handle_metrics
+
+from src.factoring.yolo_manager_factory import YoloManagerFactory
 
 app = FastAPI(ssl_keyfile="api/private.key", ssl_certfile="api/cert.crt")
-
 
 origins = [
     "http://localhost",
@@ -33,8 +27,8 @@ app.add_middleware(
 app.add_middleware(PrometheusMiddleware)
 app.add_route("/metrics", handle_metrics)
 
-#@app.post("/uploadfile/")
-#async def upload_file(selectedFile: UploadFile):
+# @app.post("/uploadfile/")
+# async def upload_file(selectedFile: UploadFile):
 #    file_location = f"{selectedFile.filename}"
 #    
 #    with open(file_location, "wb+") as file_object:
@@ -49,30 +43,54 @@ app.add_route("/metrics", handle_metrics)
 #    return prediction
 
 
-
 manager = YoloManagerFactory().get_final_dl_manager("models/detection_model.onnx")
 app = FastAPI()
 
+
 def get_filename_without_ext(filename):
     return path.splitext(filename)[0]
+
+
+def get_extension(filename):
+    return path.splitext(filename)[-1].replace(".", "")
+
 
 @app.post("/uploadfile/")
 async def upload_file(selectedFile: UploadFile):
     pred = manager.predict(selectedFile.file.read())
     filename = get_filename_without_ext(selectedFile.filename)
+    ext = get_extension(selectedFile.filename)
 
-    response = StreamingResponse(io.BytesIO(pred), media_type="image/jpg")
-    response.headers["Content-Disposition"] = f"attachment;filename={filename}_predicted.jpg"
+    response = StreamingResponse(io.BytesIO(pred), media_type=f"image/{ext}")
+    response.headers["Content-Disposition"] = f"attachment;filename={filename}_predicted.{ext}"
 
     return response
 
-def archivate(pred, files):
-    zip_io = io.BytesIO()
 
-    with zipfile.ZipFile(zip_io, mode='w', compression=zipfile.ZIP_DEFLATED) as temp_zip:
-        for i, p in enumerate(pred):
-            img_filename = f"{get_filename_without_ext(files[i])}_predicted.jpg"
-            temp_zip.writestr(img_filename, p)
+#not used but in perspective
 
-    return zip_io
-
+# @app.post("/uploadfiles/")
+# async def upload_file(selectedFile: list[UploadFile]):
+#     pred = manager.predict([sf.file.read() for sf in selectedFile])
+#
+#     zip_io = archivate(pred, [sf.filename for sf in selectedFile])
+#
+#     return StreamingResponse(
+#         iter([zip_io.getvalue()]),
+#         media_type="application/x-zip-compressed",
+#         headers={"Content-Disposition": f"attachment; filename=predictions.zip"}
+#     )
+#
+#
+# def archivate(pred, files):
+#     zip_io = io.BytesIO()
+#
+#     with zipfile.ZipFile(zip_io, mode='w', compression=zipfile.ZIP_DEFLATED) as temp_zip:
+#         for i, p in enumerate(pred):
+#             img_name = get_filename_without_ext(files[i])
+#             img_ext = get_extension(files[i])
+#
+#             img_filename = f"{img_name}_predicted.{img_ext}"
+#             temp_zip.writestr(img_filename, p)
+#
+#     return zip_io


### PR DESCRIPTION
Что исправлено:
1. Имя в переменной, т.к. он влияет на формирование запроса. Изначально был selectedFile, при копировании стал selected_file и после правки стал вновь selectedFile.
2. Реализован учет формата картинки не только jpg